### PR TITLE
Fix connector since window handling

### DIFF
--- a/docs/core_algorithm.md
+++ b/docs/core_algorithm.md
@@ -86,6 +86,8 @@ The initial production-grade implementation in this repository ships with:
 - `realdeals.scoring.DealScorer` – Deterministic feature weighting for discount, rarity, freshness, trust, and inventory signals.
 - `realdeals.pipeline.DealPipeline` – Coordinates fetching from pluggable connectors, deduplicates candidates, filters by
   freshness/discount thresholds, scores every eligible listing, and guarantees the final collection contains exactly ten items.
+  Connectors receive a `since` timestamp derived from the configured freshness window so they can avoid returning stale
+  inventory.
 - `realdeals.tests.test_pipeline` – Pytest suite covering deduplication, eligibility filtering, scarcity handling, and the
   "exactly ten" invariant.
 

--- a/realdeals/pipeline.py
+++ b/realdeals/pipeline.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Iterable, Protocol, Sequence
 
 from .models import Deal, DealScore, ensure_aware
@@ -62,8 +62,13 @@ class DealPipeline:
 
     def _collect_deals(self) -> list[Deal]:
         deals: list[Deal] = []
+        since_time: datetime | None
+        if self.freshness_cutoff_hours <= 0:
+            since_time = None
+        else:
+            since_time = self.now - timedelta(hours=self.freshness_cutoff_hours)
         for connector in self.connectors:
-            deals.extend(connector.fetch_deals(since=self.now))
+            deals.extend(connector.fetch_deals(since=since_time))
         if not deals:
             raise DealCurationError("No deals were returned by connectors")
         return deals

--- a/realdeals/tests/test_pipeline.py
+++ b/realdeals/tests/test_pipeline.py
@@ -19,6 +19,18 @@ class StaticConnector:
         return self._deals
 
 
+class SinceAwareConnector:
+    def __init__(self, deals: Sequence[Deal]) -> None:
+        self._deals = list(deals)
+        self.requested_since: datetime | None = None
+
+    def fetch_deals(self, *, since: datetime | None = None) -> Sequence[Deal]:  # type: ignore[override]
+        self.requested_since = since
+        if since is None:
+            return list(self._deals)
+        return [deal for deal in self._deals if deal.listed_at >= since]
+
+
 def _deal(
     *,
     id: str,
@@ -117,3 +129,43 @@ def test_pipeline_prioritises_rarity_on_ties() -> None:
     top_deals = pipeline.run()
 
     assert [deal.deal.id for deal in top_deals] == ["rare", "common"]
+
+
+def test_pipeline_passes_expected_since_to_connectors() -> None:
+    now = datetime(2024, 1, 10, tzinfo=timezone.utc)
+    freshness_cutoff = 48
+    expected_since = now - timedelta(hours=freshness_cutoff)
+    fresh_deal = Deal(
+        id="fresh",
+        title="Fresh Deal",
+        url="https://example.com/fresh",
+        price=10,
+        original_price=100,
+        source="trusted_marketplace",
+        listed_at=now - timedelta(hours=2),
+        rarity_score=0.5,
+        inventory=5,
+    )
+    stale_deal = Deal(
+        id="stale",
+        title="Stale Deal",
+        url="https://example.com/stale",
+        price=10,
+        original_price=100,
+        source="trusted_marketplace",
+        listed_at=now - timedelta(hours=120),
+        rarity_score=0.5,
+        inventory=5,
+    )
+    connector = SinceAwareConnector([fresh_deal, stale_deal])
+    pipeline = DealPipeline(
+        connectors=[connector],
+        now=now,
+        max_deals=1,
+        freshness_cutoff_hours=freshness_cutoff,
+    )
+
+    top_deals = pipeline.run()
+
+    assert connector.requested_since == expected_since
+    assert [deal.deal.id for deal in top_deals] == ["fresh"]


### PR DESCRIPTION
## Summary
- adjust `DealPipeline` so connectors receive a freshness-based `since` timestamp
- extend pipeline tests with a connector that respects the `since` parameter
- document the connector collection window behaviour in the core algorithm guide

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d93cd9e86c8330a85fb02bbb80d190